### PR TITLE
Fixed failing Travis-CI build due to removal of oraclejdk7. (#148)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
 


### PR DESCRIPTION
For details see:
https://github.com/travis-ci/travis-ci/issues/7019

Signed-off-by: Victor Toni <victor.toni@gmail.com>